### PR TITLE
Fix mailchimp status sync bug from airtable to pg

### DIFF
--- a/airtable_to_pg/src/sync.ts
+++ b/airtable_to_pg/src/sync.ts
@@ -29,7 +29,7 @@ async function upsertRecord(record: any) {
   const onOnOneStatus = record.get('1:1 Status');
   const onOnOneGreeter = record.get('1:1 Greeter');
   const isExperienced = record.get('Experience?') === 'Yes';
-  const mailchimpStatus = record.get('MailChimp Status?');
+  const mailchimpStatus = record.get('MailChimp Status');
 
   const input = [
     email,


### PR DESCRIPTION
The airtable column name is "Mailchimp Status", with no question mark.
![image](https://user-images.githubusercontent.com/66332/132097718-02796616-bed1-4c6e-a493-4dcdff160e78.png)
